### PR TITLE
Rework the logout system to be able to handle expired id_tokens.

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -884,6 +884,17 @@ class OAuth2Validator(RequestValidator):
         except (JWException, JWTExpired, IDToken.DoesNotExist):
             return None
 
+    def get_sub_and_jti_from_id_token_hint(self, token):
+        key = self._get_key_for_token(token)
+        if not key:
+            return None, None
+        try:
+            jwt_token = jwt.JWT(key=key, jwt=token, check_claims={})
+            claims = json.loads(jwt_token.claims)
+            return (claims["sub"], claims["jti"])
+        except (JWException, KeyError):
+            return None, None
+
     def _get_key_for_token(self, token):
         """
         Peek at the unvalidated token to discover who it was issued for

--- a/oauth2_provider/signals.py
+++ b/oauth2_provider/signals.py
@@ -3,4 +3,4 @@ from django.dispatch import Signal
 
 app_authorized = Signal()  # providing_args=["request", "token"]
 
-oidc_session_ended = Signal()  # providing_args=["request", "id_token"]
+oidc_session_ended = Signal()  # providing_args=["request", "user"]

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -3,8 +3,8 @@ import logging
 from urllib.parse import ParseResult, parse_qsl, unquote, urlencode, urlparse
 
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.models import User
 from django.contrib.auth.views import redirect_to_login
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
 from django.shortcuts import redirect, resolve_url
@@ -17,7 +17,12 @@ from django.views.generic import FormView, View
 from ..exceptions import OAuthToolkitError
 from ..forms import AllowForm
 from ..http import OAuth2ResponseRedirect
-from ..models import get_access_token_model, get_application_model, get_id_token_model, get_refresh_token_model
+from ..models import (
+    get_access_token_model,
+    get_application_model,
+    get_id_token_model,
+    get_refresh_token_model,
+)
 from ..oauth2_validators import OAuth2Validator
 from ..scopes import get_scopes_backend
 from ..settings import oauth2_settings

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -3,6 +3,7 @@ import logging
 from urllib.parse import ParseResult, parse_qsl, unquote, urlencode, urlparse
 
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import redirect_to_login
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
@@ -16,7 +17,7 @@ from django.views.generic import FormView, View
 from ..exceptions import OAuthToolkitError
 from ..forms import AllowForm
 from ..http import OAuth2ResponseRedirect
-from ..models import get_access_token_model, get_application_model, get_refresh_token_model
+from ..models import get_access_token_model, get_application_model, get_id_token_model, get_refresh_token_model
 from ..oauth2_validators import OAuth2Validator
 from ..scopes import get_scopes_backend
 from ..settings import oauth2_settings
@@ -296,7 +297,6 @@ class EndSessionView(OAuthLibMixin, View):
     """
 
     def get(self, request, *args, **kwargs):
-
         redirect_uri = request.GET.get("post_logout_redirect_uri", None)
         state = request.GET.get("state", None)
         # we'll receive an access token
@@ -304,13 +304,18 @@ class EndSessionView(OAuthLibMixin, View):
         if not token_hint:
             return HttpResponseBadRequest("missing id_token_hint")
 
-        id_token = OAuth2Validator()._load_id_token(token_hint)
-        if not id_token:
+        sub, jti = OAuth2Validator().get_sub_and_jti_from_id_token_hint(token_hint)
+        if not sub:
             return HttpResponseNotFound("id_token_hint not found")
 
-        user = id_token.user or request.user
-        self.revoke_tokens(user, id_token)
-        oidc_session_ended.send(sender=self, request=request, id_token=id_token)
+        try:
+            user = User.objects.get(id=sub)
+        except User.DoesNotExist:
+            return HttpResponseNotFound("id_token_hint not found")
+
+        self.revoke_user_tokens(user)
+        oidc_session_ended.send(sender=self, request=request, user=user)
+        get_id_token_model().objects.filter(jti=jti).delete()
 
         # state is an opaque value that will be passed as-is to the RP when
         # redirecting user to the post logout redirect URI. If redirect URI
@@ -323,8 +328,8 @@ class EndSessionView(OAuthLibMixin, View):
         # else redirect to login url
         return redirect(settings.LOGIN_URL)
 
-    def revoke_tokens(self, user, id_token):
-        access_tokens = get_access_token_model().objects.filter(user=user, id_token=id_token)
+    def revoke_user_tokens(self, user):
+        access_tokens = get_access_token_model().objects.filter(user=user)
         refresh_tokens = get_refresh_token_model().objects.filter(access_token__in=access_tokens)
 
         removed_refresh_tokens_count = refresh_tokens.delete()
@@ -332,8 +337,6 @@ class EndSessionView(OAuthLibMixin, View):
 
         removed_access_tokens_count = access_tokens.delete()
         log.info("%s accesss tokens revoked", removed_access_tokens_count)
-
-        id_token.delete()
 
     def add_url_params(url, params):
         """


### PR DESCRIPTION
Le logout marchait pas avec les tokens périmés ou supprimés de la DB par la tache de nettoyage